### PR TITLE
Bump upper bounds on process

### DIFF
--- a/haskell-coffee.cabal
+++ b/haskell-coffee.cabal
@@ -19,5 +19,5 @@ library
   -- other-modules:
   build-depends:
       base      >= 4    && <= 5
-    , process   >= 1.1  && <= 1.2
+    , process   >= 1.1  && <= 1.3
   hs-source-dirs:      src


### PR DESCRIPTION
haskell-coffee seems to work just fine with process 1.2.
